### PR TITLE
Expose "Entry" size attributes

### DIFF
--- a/lib/http_zip/entry.rb
+++ b/lib/http_zip/entry.rb
@@ -4,13 +4,14 @@ module HttpZip
   # Describes one entry in an HTTP zip archive
   # @attr_reader [String] name filename of the entry
   class Entry
-    attr_reader :name
+    attr_reader :name, :compressed_size, :uncompressed_size
 
-    def initialize(url, name, header_offset, central_directory_file_compressed_size)
+    def initialize(url, name, header_offset, central_directory_file_compressed_size, central_directory_file_uncompressed_size)
       @range_request = HttpZip::RangeRequest.new(url)
       @name = name
       @header_offset = header_offset
       @compressed_size = central_directory_file_compressed_size
+      @uncompressed_size = central_directory_file_uncompressed_size
     end
 
     # Get the decompressed content of the file entry

--- a/lib/http_zip/file.rb
+++ b/lib/http_zip/file.rb
@@ -42,7 +42,8 @@ module HttpZip
           @url,
           file_header.file_name,
           file_header.header_offset,
-          file_header.compressed_size
+          file_header.compressed_size,
+          file_header.uncompressed_size
         )
 
         # skip ahead to next file entry

--- a/test/entry_test.rb
+++ b/test/entry_test.rb
@@ -9,7 +9,8 @@ module HttpZip
       name = 'file.txt'
       header_offset = 10
       central_directory_file_compressed_size = 128
-      entry = HttpZip::Entry.new(url, name, header_offset, central_directory_file_compressed_size)
+      central_directory_file_compressed_size = 192
+      entry = HttpZip::Entry.new(url, name, header_offset, central_directory_file_compressed_size, central_directory_file_compressed_size)
 
       compression_method = 1
       file_name_length = name.length

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -9,7 +9,7 @@ require 'http_zip'
 require 'minitest/autorun'
 require 'webmock/minitest'
 
-module MiniTest
+module Minitest
   class Test
     def mock_range_request(url, file)
       stub_request(:get, url).to_return do |request|


### PR DESCRIPTION
👋 Hey there @peret!

In this PR I've modified the `Entry` class so it is initialized with the `uncompressed_size` of the file.

I've also added _getter_ methods to both `compressed_size` and `uncompressed_size` so this information is accessible from outside the class.